### PR TITLE
added refeeder links to partner root id columns

### DIFF
--- a/flywiredashapps/connectivity/callbacks.py
+++ b/flywiredashapps/connectivity/callbacks.py
@@ -217,6 +217,12 @@ def register_callbacks(app, config=None):
         up_data = up_df.to_dict("records")
         down_data = down_df.to_dict("records")
 
+        up_cols[0]["presentation"] = "markdown"
+        down_cols[0]["presentation"] = "markdown"
+
+        print(up_cols[0]["presentation"])
+        print(down_cols[0]["presentation"])
+
         # builds list of figures to pass to children of graph_div #
         figs = [
             html.Div(
@@ -548,7 +554,14 @@ def register_callbacks(app, config=None):
         table_data -- data from upstream table
         """
 
+        # converts table data to dataframe #
         upstream_df = pd.DataFrame(table_data)
+
+        # converts markdown back into normal root id #
+        upstream_df["Upstream Partner ID"] = [
+            x[1:19] for x in upstream_df["Upstream Partner ID"]
+        ]
+
         return dcc.send_data_frame(upstream_df.to_csv, "upstream_table.csv")
 
     # defines callback to download downstream table as csv on button press #
@@ -566,8 +579,13 @@ def register_callbacks(app, config=None):
         table_data -- data from downstream table
         """
 
+        # converts table data to dataframe #
         downstream_df = pd.DataFrame(table_data)
-        downstream_df.head()
+
+        # converts markdown back into normal root id #
+        downstream_df["Downstream Partner ID"] = [
+            x[1:19] for x in downstream_df["Downstream Partner ID"]
+        ]
         return dcc.send_data_frame(downstream_df.to_csv, "downstream_table.csv")
 
     # defines callback that generates partner app link  #

--- a/flywiredashapps/connectivity/utils.py
+++ b/flywiredashapps/connectivity/utils.py
@@ -568,6 +568,11 @@ def makePartnerDataFrame(root_id, cleft_thresh, upstream=False, config={}):
         .reset_index(drop=True)
     )
 
+    # converts root ids into markdown-readable refeeder links #
+    partner_df[title_name] = [
+        refeedLink(str(x), config) for x in partner_df[title_name]
+    ]
+
     # needs to be converted to strings or the dash table will round the IDs #
     return partner_df.astype(str)
 
@@ -934,6 +939,21 @@ def portUrl(input_ids, app_choice, config={}):
 
     out_url = base + query
     return out_url
+
+
+def refeedLink(root_id, config={}):
+    """Convert root id into markdown-format refeed link.
+
+    Keyword arguments:
+    root_id -- string-format 18-digit root id
+    config -- dictionary of config settings (default {})
+    """
+
+    base = config.get("con_app_base_url", None)
+    query = "?input_field=" + root_id + "&cleft_thresh_field=50"
+    out_url = base + query
+    markdown_url = "[" + root_id + "](" + out_url + ")"
+    return markdown_url
 
 
 def rootsToNucCoords(roots, config={}):


### PR DESCRIPTION
Converted values in root id column of partner tables to links that will feed the id back into the connectivity app in a new tab when clicked using markdown, and adjusted the csv downloader to remove the markdown syntax before packaging the files.