### PR TITLE
fixed link targets to open multiple new tabs

### DIFF
--- a/flywiredashapps/connectivity/callbacks.py
+++ b/flywiredashapps/connectivity/callbacks.py
@@ -246,7 +246,7 @@ def register_callbacks(app, config=None):
                         "Generate NG Link Using Selected Partners",
                         id="link_button",
                         n_clicks=0,
-                        target="tab",
+                        target="_blank",
                         style={
                             "margin-top": "5px",
                             "margin-right": "5px",
@@ -288,7 +288,7 @@ def register_callbacks(app, config=None):
                         "Select Neuron to Port to Summary App",
                         id="summary_link_button",
                         n_clicks=0,
-                        target="tab",
+                        target="_blank",
                         style={
                             "margin-top": "5px",
                             "margin-right": "5px",
@@ -314,7 +314,7 @@ def register_callbacks(app, config=None):
                         "Select 2 Neurons to Port to Partner App",
                         id="partner_link_button",
                         n_clicks=0,
-                        target="tab",
+                        target="_blank",
                         style={
                             "margin-top": "5px",
                             "margin-right": "5px",

--- a/flywiredashapps/partner/callbacks.py
+++ b/flywiredashapps/partner/callbacks.py
@@ -230,7 +230,7 @@ def register_callbacks(app, config=None):
                 "Generate NG Link Using Partners",
                 id="link_button",
                 n_clicks=0,
-                target="tab",
+                target="_blank",
                 style={
                     "margin-top": "5px",
                     "margin-right": "5px",
@@ -246,7 +246,7 @@ def register_callbacks(app, config=None):
                 "Port Neuron A to Connectivity App",
                 id="connectivity_link_button_A",
                 n_clicks=0,
-                target="tab",
+                target="_blank",
                 style={
                     "margin-top": "5px",
                     "margin-right": "5px",
@@ -262,7 +262,7 @@ def register_callbacks(app, config=None):
                 "Port Neuron B to Connectivity App",
                 id="connectivity_link_button_B",
                 n_clicks=0,
-                target="tab",
+                target="_blank",
                 style={
                     "margin-top": "5px",
                     "margin-right": "5px",
@@ -278,7 +278,7 @@ def register_callbacks(app, config=None):
                 "Port Neurons to Summary App",
                 id="summary_link_button",
                 n_clicks=0,
-                target="tab",
+                target="_blank",
                 style={
                     "margin-top": "5px",
                     "margin-right": "5px",

--- a/flywiredashapps/summary/callbacks.py
+++ b/flywiredashapps/summary/callbacks.py
@@ -67,7 +67,7 @@ def register_callbacks(app, config=None):
                             "Generate NG Link Using Selected Root IDs",
                             id="link_button",
                             n_clicks=0,
-                            target="tab",
+                            target="_blank",
                             style={
                                 "margin-top": "5px",
                                 "margin-right": "5px",
@@ -95,7 +95,7 @@ def register_callbacks(app, config=None):
                             "Select Neuron to Port to Connectivity App",
                             id="connectivity_link_button",
                             n_clicks=0,
-                            target="tab",
+                            target="_blank",
                             style={
                                 "margin-top": "5px",
                                 "margin-right": "5px",
@@ -121,7 +121,7 @@ def register_callbacks(app, config=None):
                             "Select 2 Neurons to Port to Partner App",
                             id="partner_link_button",
                             n_clicks=0,
-                            target="tab",
+                            target="_blank",
                             style={
                                 "margin-top": "5px",
                                 "margin-right": "5px",


### PR DESCRIPTION
Switched link targets from "tab" to "_blank" to open a new tab with each click instead of overwriting the previous opened tab.